### PR TITLE
Dont restart nodes that already returned success

### DIFF
--- a/Runtime/Composites/Sequencer.cs
+++ b/Runtime/Composites/Sequencer.cs
@@ -5,8 +5,10 @@ using UnityEngine;
 namespace TheKiwiCoder {
     [System.Serializable]
     public class Sequencer : CompositeNode {
+        int lastNodeFinished;
 
         protected override void OnStart() {
+            lastNodeFinished = -1;
         }
 
         protected override void OnStop() {
@@ -14,12 +16,16 @@ namespace TheKiwiCoder {
 
         protected override State OnUpdate() {
             for (int i = 0; i < children.Count; ++i) {
+                if (i <= lastNodeFinished) continue;
+
                 var childStatus = children[i].Update();
-                
+
                 if (childStatus == State.Running) {
                     return State.Running;
                 } else if (childStatus == State.Failure) {
                     return State.Failure;
+                } else if (childStatus == State.Success) {
+                    lastNodeFinished = i;
                 }
             }
 


### PR DESCRIPTION
I made a fix to the sequence node so it run's through all of it's child nodes once.

I needed a sequence with:
[Condition]  [Wait] [LongAction]

Where the long action should return running over several Update's of the tree, but on the next update the Wait node would restart and wait again. 

In the example random walk you can see the problem when you insert another Wait node between random position and move to position.