### PR TITLE
change duration to NodeProperty<float> in Wait node

### DIFF
--- a/Runtime/Actions/Wait.cs
+++ b/Runtime/Actions/Wait.cs
@@ -7,7 +7,8 @@ namespace TheKiwiCoder {
     [System.Serializable]
     public class Wait : ActionNode {
 
-        [Tooltip("Amount of time to wait before returning success")] public float duration = 1;
+		[Tooltip("Amount of time to wait before returning success")] public NodeProperty<float> duration = new NodeProperty<float>() { Value = 1 };
+        
         float startTime;
 
         protected override void OnStart() {
@@ -18,9 +19,9 @@ namespace TheKiwiCoder {
         }
 
         protected override State OnUpdate() {
-            
+
             float timeRemaining = Time.time - startTime;
-            if (timeRemaining > duration) {
+            if (timeRemaining > duration.Value) {
                 return State.Success;
             }
             return State.Running;

--- a/Runtime/Actions/Wait.cs
+++ b/Runtime/Actions/Wait.cs
@@ -7,7 +7,7 @@ namespace TheKiwiCoder {
     [System.Serializable]
     public class Wait : ActionNode {
 
-		[Tooltip("Amount of time to wait before returning success")] public NodeProperty<float> duration = new NodeProperty<float>() { Value = 1 };
+		[Tooltip("Amount of time to wait before returning success")] public NodeProperty<float> duration = new NodeProperty<float>() { Value = 1.0f };
         
         float startTime;
 


### PR DESCRIPTION
Changed the `duration` to be a `NodeProperty<float>` instead of a simple `float` in the Wait node